### PR TITLE
Better describe how to get the bundle path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ One bonus is that my tool skips writing rendered image to disk by encoding the c
 This project was written with Xcode 13.2.1 with all latest Swift features. My machine was running on macOS 12.2.1. 
 
 # Usage
-Before using the tool, salvage the temporary HTML and JavaScript files Remotion generates from cache during a build. Patch the HTML file by adding a `.` in front of the JavaScript file path in `<script>` node. 
+Before using the tool, take the bundle that Remotion generates during render. The bundle path gets written when passing [`--log=verbose`](https://www.remotion.dev/docs/cli#--log) to the render command. Patch the HTML file by adding a `.` in front of the JavaScript file path in `<script>` node. 
 
 The input file path should point to the `index.html`
 


### PR DESCRIPTION
Mentioning that the bundle path gets printed when passing --log=verbose.

BTW, in the next version there will also be a bundle() command or maybe even a CLI command for generating a bundle. It will be a first step in making it easier to use your renderer.